### PR TITLE
keyboard issue fixed

### DIFF
--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -21,6 +21,7 @@ function MyTabs() {
   return (
     <Tab.Navigator
       screenOptions={{
+        tabBarHideOnKeyboard: true,
         tabBarStyle: {
           borderTopWidth: 0,
         },
@@ -85,18 +86,9 @@ function Navigation() {
         screenOptions={{ headerShown: false }}
         initialRouteName="Main"
       >
-        <Stack.Screen
-          name="Login"
-          component={Login}
-        />
-        <Stack.Screen
-          name="Main"
-          component={MyTabs}
-        />
-        <Stack.Screen
-          name="Details"
-          component={Details}
-        />
+        <Stack.Screen name="Login" component={Login} />
+        <Stack.Screen name="Main" component={MyTabs} />
+        <Stack.Screen name="Details" component={Details} />
       </Stack.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
- When I clicked on the search field, tab bar always appears at the top of the keyboard. So I fixed it.
  - In navigation folder, I added `tabBarHideOnKeyboard `feature into the `Tab.Navigator`  `screenOptions` area: 
      `  tabBarHideOnKeyboard: true`

**Here is the result:** 

https://user-images.githubusercontent.com/95627279/202794431-6c05d1c4-6f71-4743-88d1-ed503013a953.mp4

